### PR TITLE
Remove telnet and add web interface

### DIFF
--- a/samples/rt/3-node-network.groovy
+++ b/samples/rt/3-node-network.groovy
@@ -17,14 +17,15 @@ println '''
 
 Nodes: 1, 2, 3
 
-To connect to node 2 or node 3 via telnet:
-  telnet localhost 5102
-  telnet localhost 5103
-
 To connect to nodes 1, 2 or 3 via unet sh:
   bin/unet sh localhost 1101
   bin/unet sh localhost 1102
   bin/unet sh localhost 1103
+
+To conect to nodes via web interface open browser
+  http://localhost:8081/  for node 1
+  http://localhost:8082/  for node 2
+  http://localhost:8083/  for node 3
 
 Connected to node 1...
 Press ^D to exit
@@ -37,7 +38,7 @@ platform = RealTimePlatform   // use real-time mode
 
 // run the simulation forever
 simulate {
-  node '1', remote: 1101, address: 1, location: [ 0.km, 0.km, -15.m], shell: true, stack: "$home/etc/initrc-stack"
-  node '2', remote: 1102, address: 2, location: [ 1.km, 0.km, -15.m], shell: 5102, stack: "$home/etc/initrc-stack"
-  node '3', remote: 1103, address: 3, location: [-1.km, 0.km, -15.m], shell: 5103, stack: "$home/etc/initrc-stack"
+  node '1', remote: 1101, address: 1, location: [ 0.km, 0.km, -15.m], shell: [CONSOLE, WEB(8080,'/1')], web: 8081, stack: "$home/etc/initrc-stack"
+  node '2', remote: 1102, address: 2, location: [ 1.km, 0.km, -15.m], shell: [TCP(5102), WEB(8080,'/2')], web: 8082, stack: "$home/etc/initrc-stack"
+  node '3', remote: 1103, address: 3, location: [-1.km, 0.km, -15.m], shell: [TCP(5103), WEB(8080,'/3')], web: 8083, stack: "$home/etc/initrc-stack"
 }

--- a/samples/rt/3-node-network.groovy
+++ b/samples/rt/3-node-network.groovy
@@ -39,6 +39,6 @@ platform = RealTimePlatform   // use real-time mode
 // run the simulation forever
 simulate {
   node '1', remote: 1101, address: 1, location: [ 0.km, 0.km, -15.m], shell: [CONSOLE, WEB(8080,'/1')], web: 8081, stack: "$home/etc/initrc-stack"
-  node '2', remote: 1102, address: 2, location: [ 1.km, 0.km, -15.m], shell: [TCP(5102), WEB(8080,'/2')], web: 8082, stack: "$home/etc/initrc-stack"
-  node '3', remote: 1103, address: 3, location: [-1.km, 0.km, -15.m], shell: [TCP(5103), WEB(8080,'/3')], web: 8083, stack: "$home/etc/initrc-stack"
+  node '2', remote: 1102, address: 2, location: [ 1.km, 0.km, -15.m], shell: [WEB(8080,'/2')], web: 8082, stack: "$home/etc/initrc-stack"
+  node '3', remote: 1103, address: 3, location: [-1.km, 0.km, -15.m], shell: [WEB(8080,'/3')], web: 8083, stack: "$home/etc/initrc-stack"
 }


### PR DESCRIPTION
Remove telnet and add web interface to default rt sim script, since telnet access has been removed, and the web interface is the supported mechanism for configuring the modem in the future.