### PR TITLE
Fix in the super tdma script

### DIFF
--- a/archive/samples/super-tdma/e3-network.groovy
+++ b/archive/samples/super-tdma/e3-network.groovy
@@ -55,7 +55,6 @@ simulate time, {
     n1.startup = {
       def phy = agentForService PHYSICAL
       phy[Physical.DATA].frameLength = phy[Physical.CONTROL].frameLength
-      phy[Physical.DATA].dataRate = phy[Physical.CONTROL].dataRate
       add new TickerBehavior(1000*slot, {
         def slen = schedule[i].size()
         def s = schedule[i][(tickCount-1)%slen]


### PR DESCRIPTION
There was a bug in the `e3-network.groovy` I believe. The frame length and data rate of the DATA channel was set such that the frame duration turns out to be larger than time slot length, resulting in collisions and 0 throughput. Fixed in this pull request. 