### PR TITLE
Fixing the issue raised relating to send returning None

### DIFF
--- a/unetsocket/python/unetpy/__init__.py
+++ b/unetsocket/python/unetpy/__init__.py
@@ -391,6 +391,7 @@ class UnetSocket():
     def cancel(self):
         """Cancels an ongoing blocking receive()."""
         if self.waiting:
+            self.gw.cancel = True
             self.gw.cv.acquire()
             self.gw.cv.notify()
             self.gw.cv.release()


### PR DESCRIPTION
This bug was introduced while trying to fix `UnetSocket.cancel()` behavior. The problem is fixed in this pull request along with the following commit in fjagepy https://github.com/org-arl/fjage/commit/2dafb65e195c4987e35167cf6849c74b40fcebc1

The following are the test results:

## On TX node
```
>>> from unetpy import UnetSocket
>>> s = UnetSocket('localhost',1101)
>>> s.send('hellooo',31)
True
>>>
```
## On Rx node
```
>>> from unetpy import UnetSocket
>>> s = UnetSocket('localhost',1102)
>>> rx = s.receive()
>>> print(rx)
DatagramNtf:INFORM[from:232 to:31 protocol:0 priority:NORMAL sentAt:1617006904512  ... (7 bytes)]
>>> print('from node : ',bytearray(rx.data).decode())
from node :  hellooo
>>>
```

## Regression test results on unetpy:

```
python test/test.py
Starting 2-node simulation...
Starting tests...
Test agents
.Test bind and connect
.Test cancel
.Test communication
.Test gateway
.Test unet socket
.Test timeout
.
----------------------------------------------------------------------
Ran 7 tests in 6.220s

OK
Stopping 2-node simulation...
Simulation interrupted!
```



