### PR TITLE
Support for Reliable Datagram transmission using UnetSocket C APIs

### DIFF
--- a/unetsocket/c/Makefile
+++ b/unetsocket/c/Makefile
@@ -10,7 +10,7 @@ all: libs
 	rm -rf *.zip
 	rm -rf fjage-*
 
-samples: txdata rxdata range setpowerlevel txsignal pbrecord bbrecord npulses wakeup rs232_wakeup
+samples: txdata txdata-reliable rxdata range setpowerlevel txsignal pbrecord bbrecord npulses wakeup rs232_wakeup
 	rm -rf *.zip
 	rm -rf fjage-*
 
@@ -36,6 +36,12 @@ txdata.o: samples/txdata.c unet.h fjage.h
 
 txdata: txdata.o
 	$(CC) -o samples/txdata samples/txdata.o libunet.a libfjage.a -lpthread -lm
+
+txdata-reliable.o: samples/txdata-reliable.c unet.h fjage.h
+	$(CC) $(CFLAGS) -c samples/txdata-reliable.c -o samples/txdata-reliable.o
+
+txdata-reliable: txdata-reliable.o
+	$(CC) -o samples/txdata-reliable samples/txdata-reliable.o libunet.a libfjage.a -lpthread -lm
 
 rxdata.o: samples/rxdata.c unet.h fjage.h
 	$(CC) $(CFLAGS) -c samples/rxdata.c -o samples/rxdata.o
@@ -102,7 +108,7 @@ test_unet: test_unet.o
 	$(CC) -o test/test_unet unet_ext.o test/test_unet.o libunet.a libfjage.a -lpthread -lm
 
 clean:
-	rm -rf c-api libunet.a *.o samples/*.o test/*.o test/test_unet samples/wakeup samples/rs232_wakeup samples/txdata samples/rxdata samples/range samples/setpowerlevel samples/txsignal samples/pbrecord samples/bbrecordedsignal.txt samples/pbrecordedsignal.txt samples/bbrecord samples/npulses samples/gpio
+	rm -rf c-api libunet.a *.o samples/*.o test/*.o test/test_unet samples/wakeup samples/rs232_wakeup samples/txdata samples/txdata-reliable samples/rxdata samples/range samples/setpowerlevel samples/txsignal samples/pbrecord samples/bbrecordedsignal.txt samples/pbrecordedsignal.txt samples/bbrecord samples/npulses samples/gpio
 	rm -rf "$(FJAGE_DIR)" "$(FJAGE_VER).zip" fjage.h libfjage.a kissfft kiss_fft.h fjage
 	rm -rf $(BUILD)
 

--- a/unetsocket/c/Makefile.package
+++ b/unetsocket/c/Makefile.package
@@ -9,7 +9,7 @@ libs: libfjage.a libunet.a
 	rm -rf *.zip
 	rm -rf fjage-*
 
-samples: txdata rxdata range setpowerlevel txsignal pbrecord bbrecord npulses wakeup rs232_wakeup gpio
+samples: txdata txdata-reliable rxdata range setpowerlevel txsignal pbrecord bbrecord npulses wakeup rs232_wakeup gpio
 	rm -rf *.zip
 	rm -rf fjage-*
 
@@ -29,6 +29,12 @@ txdata.o: samples/txdata.c unet.h fjage.h
 
 txdata: txdata.o
 	$(CC) -o samples/txdata samples/txdata.o libunet.a libfjage.a -lpthread -lm
+
+txdata-reliable.o: samples/txdata-reliable.c unet.h fjage.h
+	$(CC) $(CFLAGS) -c samples/txdata-reliable.c -o samples/txdata-reliable.o
+
+txdata-reliable: txdata-reliable.o
+	$(CC) -o samples/txdata-reliable samples/txdata-reliable.o libunet.a libfjage.a -lpthread -lm
 
 rxdata.o: samples/rxdata.c unet.h fjage.h
 	$(CC) $(CFLAGS) -c samples/rxdata.c -o samples/rxdata.o
@@ -101,5 +107,5 @@ test_unet: test_unet.o
 	$(CC) -o test/test_unet unet_ext.o test/test_unet.o libunet.a libfjage.a -lpthread -lm
 
 clean:
-	rm -rf c-api libunet.a *.o samples/*.o test/*.o test/test_unet samples/wakeup samples/rs232_wakeup samples/txdata samples/rxdata samples/range samples/setpowerlevel samples/txsignal samples/pbrecord samples/bbrecordedsignal.txt samples/pbrecordedsignal.txt samples/bbrecord samples/npulses samples/gpio
+	rm -rf c-api libunet.a *.o samples/*.o test/*.o test/test_unet samples/wakeup samples/rs232_wakeup samples/txdata samples/txdata-reliable samples/rxdata samples/range samples/setpowerlevel samples/txsignal samples/pbrecord samples/bbrecordedsignal.txt samples/pbrecordedsignal.txt samples/bbrecord samples/npulses samples/gpio
 

--- a/unetsocket/c/samples/txdata-reliable.c
+++ b/unetsocket/c/samples/txdata-reliable.c
@@ -5,7 +5,7 @@
 // In terminal window (an example):
 //
 // $ make samples
-// $ ./txdata <ip_address> <rx_node_address> [port]
+// $ ./txdata-reliable <ip_address> <rx_node_address> [port]
 //
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -35,12 +35,12 @@ int main(int argc, char *argv[]) {
   uint8_t data[NBYTES] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
   int rv;
   if (argc <= 2) {
-    error("Usage : txdata <ip_address> <rx_node_address> [port] \n"
+    error("Usage : txdata-reliable <ip_address> <rx_node_address> [port] \n"
       "ip_address: IP address of the transmitter modem. \n"
       "rx_node_address: Node address of the receiver modem. \n"
       "port: port number of transmitter modem. \n"
       "A usage example: \n"
-      "txdata 192.168.1.20 5 1100\n");
+      "txdata-reliable 192.168.1.20 5 1100\n");
     return -1;
   } else {
     address = (int)strtol(argv[2], NULL, 10);
@@ -63,7 +63,7 @@ int main(int argc, char *argv[]) {
 
 // Transmit data
   printf("Transmitting %d bytes of data to %d\n", NBYTES, address);
-  rv = unetsocket_send(sock, data, NBYTES, address, DATA, true);
+  rv = unetsocket_send_reliable(sock, data, NBYTES, address, DATA);
   if (rv != 0) return error("Error transmitting data");
 
 // Wait for DatagramDeliveryNtf (or) DatagramFailureNtf message

--- a/unetsocket/c/samples/txdata.c
+++ b/unetsocket/c/samples/txdata.c
@@ -62,7 +62,7 @@ int main(int argc, char *argv[]) {
 
 // Transmit data
   printf("Transmitting %d bytes of data to %d\n", NBYTES, address);
-  rv = unetsocket_send(sock, data, NBYTES, address, DATA, false);
+  rv = unetsocket_send(sock, data, NBYTES, address, DATA);
 
   if (rv != 0) return error("Error transmitting data");
 

--- a/unetsocket/c/unet.c
+++ b/unetsocket/c/unet.c
@@ -351,9 +351,8 @@ long unetsocket_get_timeout(unetsocket_t sock) {
 }
 
 // NOTE: changed const uint8_t* to uint8_t*
-int unetsocket_send(unetsocket_t sock, uint8_t* data, int len, int to, int protocol, bool reliability) {
+int unetsocket_send(unetsocket_t sock, uint8_t* data, int len, int to, int protocol) {
   if (sock == NULL) return -1;
-  if ((to == 0) && (reliability == true)) return -1;
   _unetsocket_t *usock = sock;
   fjage_msg_t msg;
   int rv;
@@ -361,7 +360,21 @@ int unetsocket_send(unetsocket_t sock, uint8_t* data, int len, int to, int proto
   if (data != NULL) fjage_msg_add_byte_array(msg, "data", data, len);
   fjage_msg_add_int(msg, "to", to);
   fjage_msg_add_int(msg, "protocol", protocol);
-  fjage_msg_add_bool(msg, "reliability", reliability);
+  rv = unetsocket_send_request(usock, msg);
+  return rv;
+}
+
+int unetsocket_send_reliable(unetsocket_t sock, uint8_t* data, int len, int to, int protocol) {
+  if (sock == NULL) return -1;
+  if (to == 0) return -1; // broadcast with reliability is not allowed
+  _unetsocket_t *usock = sock;
+  fjage_msg_t msg;
+  int rv;
+  msg = fjage_msg_create("org.arl.unet.DatagramReq", FJAGE_REQUEST);
+  if (data != NULL) fjage_msg_add_byte_array(msg, "data", data, len);
+  fjage_msg_add_int(msg, "to", to);
+  fjage_msg_add_int(msg, "protocol", protocol);
+  fjage_msg_add_bool(msg, "reliability", true);
   rv = unetsocket_send_request(usock, msg);
   return rv;
 }

--- a/unetsocket/c/unet.c
+++ b/unetsocket/c/unet.c
@@ -351,8 +351,9 @@ long unetsocket_get_timeout(unetsocket_t sock) {
 }
 
 // NOTE: changed const uint8_t* to uint8_t*
-int unetsocket_send(unetsocket_t sock, uint8_t* data, int len, int to, int protocol) {
+int unetsocket_send(unetsocket_t sock, uint8_t* data, int len, int to, int protocol, bool reliability) {
   if (sock == NULL) return -1;
+  if ((to == 0) && (reliability == true)) return -1;
   _unetsocket_t *usock = sock;
   fjage_msg_t msg;
   int rv;
@@ -360,6 +361,7 @@ int unetsocket_send(unetsocket_t sock, uint8_t* data, int len, int to, int proto
   if (data != NULL) fjage_msg_add_byte_array(msg, "data", data, len);
   fjage_msg_add_int(msg, "to", to);
   fjage_msg_add_int(msg, "protocol", protocol);
+  fjage_msg_add_bool(msg, "reliability", reliability);
   rv = unetsocket_send_request(usock, msg);
   return rv;
 }

--- a/unetsocket/c/unet.h
+++ b/unetsocket/c/unet.h
@@ -194,7 +194,20 @@ long unetsocket_get_timeout(unetsocket_t sock);
 /// @param protocol         Protocol number
 /// @return                 0 on success, -1 otherwise
 
-int unetsocket_send(unetsocket_t sock, uint8_t* data, int len, int to, int protocol, bool reliability);
+int unetsocket_send(unetsocket_t sock, uint8_t* data, int len, int to, int protocol);
+
+/// Transmits a datagram to the specified node address using the specified protocol with reliability enabled.
+/// Protocol numbers between Protocol.DATA+1 to Protocol.USER-1 are considered reserved,
+/// and cannot be used for sending datagrams using the socket.
+///
+/// @param sock             Unet socket
+/// @param data             Data to send across
+/// @param len              Number of bytes in the data
+/// @param to               Destination node address
+/// @param protocol         Protocol number
+/// @return                 0 on success, -1 otherwise
+
+int unetsocket_send_reliable(unetsocket_t sock, uint8_t* data, int len, int to, int protocol);
 
 /// Transmits a datagram to the specified node address using the specified protocol.
 /// Protocol numbers between Protocol.DATA+1 to Protocol.USER-1 are considered reserved,

--- a/unetsocket/c/unet.h
+++ b/unetsocket/c/unet.h
@@ -194,7 +194,7 @@ long unetsocket_get_timeout(unetsocket_t sock);
 /// @param protocol         Protocol number
 /// @return                 0 on success, -1 otherwise
 
-int unetsocket_send(unetsocket_t sock, uint8_t* data, int len, int to, int protocol);
+int unetsocket_send(unetsocket_t sock, uint8_t* data, int len, int to, int protocol, bool reliability);
 
 /// Transmits a datagram to the specified node address using the specified protocol.
 /// Protocol numbers between Protocol.DATA+1 to Protocol.USER-1 are considered reserved,


### PR DESCRIPTION
Updated the following:

1. `unetsocket_send(..)` API updated to support reliability when transmitting datagrams.
2. Added a sample program `txdata-reliable.c` to demonstrate the usage of reliable transmission by receiving the `DatagramDeliveryNtf` or `DatagramFailureNtf` message.

An example run:
```bash
> samples/txdata-reliable localhost 242 1101                            
Connecting to localhost:1101
Transmitting 9 bytes of data to 242
Datagram delivered succesfully at the receiver node!
Transmission Complete
```