### PR TITLE
Added a sample program for executing commands on shell

### DIFF
--- a/unetsocket/c/Makefile
+++ b/unetsocket/c/Makefile
@@ -10,7 +10,7 @@ all: libs
 	rm -rf *.zip
 	rm -rf fjage-*
 
-samples: txdata txdata-reliable rxdata range setpowerlevel txsignal pbrecord bbrecord npulses wakeup rs232_wakeup
+samples: txdata txdata-reliable rxdata range setpowerlevel txsignal pbrecord bbrecord npulses execcmd wakeup rs232_wakeup
 	rm -rf *.zip
 	rm -rf fjage-*
 
@@ -85,6 +85,12 @@ npulses.o: samples/npulses.c unet.h fjage.h unet_ext.o
 npulses: npulses.o unet_ext.o
 	$(CC) -o samples/npulses unet_ext.o samples/npulses.o libunet.a libfjage.a -lpthread -lm
 
+execcmd.o: samples/execcmd.c unet.h fjage.h unet_ext.o
+	$(CC) $(CFLAGS) -c samples/execcmd.c -o samples/execcmd.o
+
+execcmd: execcmd.o unet_ext.o
+	$(CC) -o samples/execcmd unet_ext.o samples/execcmd.o libunet.a libfjage.a -lpthread -lm
+
 wakeup.o: samples/wakeup.c unet.h fjage.h unet_ext.o
 	$(CC) $(CFLAGS) -c samples/wakeup.c -o samples/wakeup.o
 
@@ -108,7 +114,7 @@ test_unet: test_unet.o
 	$(CC) -o test/test_unet unet_ext.o test/test_unet.o libunet.a libfjage.a -lpthread -lm
 
 clean:
-	rm -rf c-api libunet.a *.o samples/*.o test/*.o test/test_unet samples/wakeup samples/rs232_wakeup samples/txdata samples/txdata-reliable samples/rxdata samples/range samples/setpowerlevel samples/txsignal samples/pbrecord samples/bbrecordedsignal.txt samples/pbrecordedsignal.txt samples/bbrecord samples/npulses samples/gpio
+	rm -rf c-api libunet.a *.o samples/*.o test/*.o test/test_unet samples/wakeup samples/rs232_wakeup samples/txdata samples/txdata-reliable samples/rxdata samples/range samples/setpowerlevel samples/txsignal samples/pbrecord samples/bbrecordedsignal.txt samples/pbrecordedsignal.txt samples/bbrecord samples/npulses samples/gpio samples/execcmd
 	rm -rf "$(FJAGE_DIR)" "$(FJAGE_VER).zip" fjage.h libfjage.a kissfft kiss_fft.h fjage
 	rm -rf $(BUILD)
 

--- a/unetsocket/c/samples/execcmd.c
+++ b/unetsocket/c/samples/execcmd.c
@@ -1,0 +1,79 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Execute any valid command on shell.
+//
+// In terminal window (an example):
+//
+// $ make samples
+// $ ./execcmd <ip_address> <cmd> [port]
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "../unet.h"
+
+#ifndef _WIN32
+#include <unistd.h>
+#include <netdb.h>
+#include <sys/time.h>
+#endif
+
+static int error(const char *msg) {
+  printf("\n*** ERROR: %s\n\n", msg);
+  return -1;
+}
+
+int main(int argc, char *argv[]) {
+   unetsocket_t sock;
+   char* cmd = NULL;
+   int port = 1100;
+   if (argc <= 2) {
+      error("Usage : execcmd <ip_address> <cmd> [port] \n"
+        "ip_address: IP address of the transmitter modem. \n"
+        "cmd: Command to execute on modem's shell. \n"
+        "port: port number of the modem. \n"
+        "A usage example: \n"
+        "execcmd 192.168.1.20 ps 1100\n");
+      return -1;
+   } else {
+      cmd = argv[2];
+      if (argc > 3) port = (int)strtol(argv[3], NULL, 10);
+   }   
+#ifndef _WIN32
+// Check valid ip address
+   struct hostent *server = gethostbyname(argv[1]);
+   if (server == NULL) {
+      error("Enter a valid ip addreess\n");
+      return -1;
+   }
+#endif
+   // Open a unet socket connection to modem
+  printf("Connecting to %s:%d\n",argv[1],port);
+
+  sock = unetsocket_open(argv[1], port);
+  if (sock == NULL) return error("Couldn't open unet socket");
+
+  fjage_gw_t gw = unetsocket_get_gateway(sock);
+
+  fjage_aid_t aid = unetsocket_agent_for_service(sock, "org.arl.fjage.shell.Services.SHELL");
+  if (aid == NULL) {
+     printf("Could not find SHELL agent\n");
+     unetsocket_close(sock);
+     return -1;
+  }
+  fjage_msg_t msg = fjage_msg_create("org.arl.fjage.shell.ShellExecReq", FJAGE_REQUEST);
+  fjage_msg_set_recipient(msg, aid);
+  fjage_msg_add_string(msg, "cmd", cmd);
+  fjage_msg_t rsp = fjage_request(gw, msg, 1000);
+  if (rsp != NULL && fjage_msg_get_performative(rsp) == FJAGE_AGREE) printf("SUCCESS\n");
+  else printf("FAILURE\n");
+  if (rsp != NULL) fjage_msg_destroy(rsp);
+  fjage_aid_destroy(aid);
+
+  // Close the unet socket
+  unetsocket_close(sock);
+
+  return 0;
+
+}


### PR DESCRIPTION
A simple sample program (execcmd.c) is added to execute commands on shell using `ShellExecReq`.


A usage example to set `node.location`:

```
> samples/execcmd localhost "node.location=[0.0,0.0,-30.0]"
```

