### PR TITLE
fix(test_unet.c) Unhardcode Node Adress

### DIFF
--- a/unetsocket/c/samples/bbrecord.c
+++ b/unetsocket/c/samples/bbrecord.c
@@ -28,7 +28,7 @@ static int error(const char *msg) {
 
 int main(int argc, char *argv[]) {
   FILE *fptr;
-  fptr = (fopen("samples/bbrecordedsignal.txt", "w"));
+  fptr = (fopen("bbrecordedsignal.txt", "w"));
   if(fptr == NULL) return -1;
   unetsocket_t sock;
   int port = 1100;

--- a/unetsocket/c/samples/bbrecord.c
+++ b/unetsocket/c/samples/bbrecord.c
@@ -28,7 +28,7 @@ static int error(const char *msg) {
 
 int main(int argc, char *argv[]) {
   FILE *fptr;
-  fptr = (fopen("bbrecordedsignal.txt", "w"));
+  fptr = (fopen("samples/bbrecordedsignal.txt", "w"));
   if(fptr == NULL) return -1;
   unetsocket_t sock;
   int port = 1100;

--- a/unetsocket/c/test/test_unet.c
+++ b/unetsocket/c/test/test_unet.c
@@ -114,7 +114,7 @@ int main(int argc, char* argv[]) {
     return -1;
   }
   // ranging
-  rv = unetsocket_ext_get_range(sock_tx, 31, &range);
+  rv = unetsocket_ext_get_range(sock_tx, rx_node_address, &range);
   if (rv == 0) printf("Range measured is : %f \n", range);
   test_assert("Ranging", rv == 0);
   // send data


### PR DESCRIPTION
Address of the node to which range is requested now supplied by unetsocket_get_local_address(sock_rx);
bug fix in bbrecord