### PR TITLE
Unetsocket c update fjage

### DIFF
--- a/unetsocket/c/Makefile
+++ b/unetsocket/c/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS += -std=c99 -Wall -Wextra -Werror -Wfloat-equal -Wconversion -Wparentheses -pedantic -Wunused-parameter -Wunused-variable -Wreturn-type -Wno-unused-function -Wredundant-decls -Wreturn-type -Wunused-value -Wswitch-default -Wuninitialized -Winit-self -O2
-FJAGE_VER=b49c7ac1b071ded3dbd2a58db39818da54a202ba
+FJAGE_VER=229b37c063eec87870cf129dbf94f766a97d0cb0
 FJAGE_DIR=fjage-$(FJAGE_VER)
 BUILD = build
 BUILD_API = $(BUILD)/api


### PR DESCRIPTION
#78 

This PR attempts to fix an issue with the C API's ability to correctly receive data over UnetSocket in unet 3.4.0 by updating fjage from b49c7ac1b071ded3dbd2a58db39818da54a202ba to 229b37c063eec87870cf129dbf94f766a97d0cb0 (v1.9.1).

This PR also adds a check in test_unet.c which compares each piece of received data to the data that was transmitted to ensure data is being transmitted correctly. 

This PR passes all tests successfully using unet 3.4.0 with openjdk 1.8.0_342 on Ubuntu 20.04 LTS.